### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,0 +1,109 @@
+name: Create Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Use PATCH for fixes, use MINOR for new features and use MAJOR for breaking changes"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        required: true
+jobs:
+  build:
+    if: ${{ github.actor != 'dependabot'}}
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.prerelease.outputs.release }}
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Fetch tags to determine the latest version
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Calculate next version
+        id: next_version
+        run: |
+          # Get the latest tag, default to v0.0.0 if no tags exist
+          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "v0.0.0")
+          
+          # Extract major, minor, and patch from the tag
+          VERSION=${LATEST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          # Determine which part to bump based on the input variable
+          if [ "${{ inputs.bump }}" = "major" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [ "${{ inputs.bump }}" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          elif [ "${{ inputs.bump }}" = "patch" ]; then
+            PATCH=$((PATCH + 1))
+          else
+            echo "Invalid bump input: ${{ inputs.bump }}"
+            exit 1
+          fi
+
+          # Create the new version string
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          
+
+          # Set the new version in the GitHub environment
+          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "New version: $NEW_VERSION"
+
+      - name: Update package.json version
+        id: update_package_version
+        run: |
+          # Update the version in the root package.json
+          jq ".version = \"${NEW_VERSION}\"" package.json > package.json.tmp && mv package.json.tmp package.json
+
+          # Update the version in all packages inside the packages folder
+          for package_json in packages/*/package.json; do
+            if [ -f "$package_json" ]; then
+              echo "Updating version in $package_json to ${NEW_VERSION}"
+              jq ".version = \"${NEW_VERSION}\"" "$package_json" > "${package_json}.tmp" && mv "${package_json}.tmp" "$package_json"
+            else
+              echo "No package.json found in $package_json"
+            fi
+          done
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Build And Test
+        id: build-and-test
+        run: |
+          pnpm build
+          pnpm test
+
+      - name: Commit changes
+        run: |
+          # Configure Git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Commit and push the changes
+          git add .
+          git commit -m "Bump version to ${NEW_TAG}"
+          git push origin HEAD:main
+          
+          git tag $NEW_TAG
+          git push origin $NEW_TAG
+
+      # Create a draft release
+      - name: Create GitHub draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$NEW_VERSION" \
+            --draft \
+            --generate-notes

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -1,0 +1,50 @@
+name: On Release Published
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  tag_bump_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Check if the release is not a pre-release
+        id: check_prerelease
+        run: |
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "This is a pre-release. Exiting."
+            exit 0
+          fi
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Configure npm with token
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish all packages
+        run: |
+          # Loop through all package.json files in the packages directory
+          for package_json in packages/*/package.json; do
+            package_dir=$(dirname "$package_json")
+            echo "Publishing package in $package_dir..."
+
+            # Check if the package is private, skip if true
+            if jq -e '.private == true' "$package_json" > /dev/null; then
+              echo "Skipping private package in $package_dir"
+              continue
+            fi
+
+            cd "$package_dir"
+            # Publish the package
+            npm publish --access public
+            cd ../../
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds workflows for create draft release and publish to NPM

This is a rough representation of the new flow.

![mermaid-diagram-2024-12-15-114655](https://github.com/user-attachments/assets/dc5ab6dd-4df1-4c07-a5de-66361f86f6ba)

I would say that the main difference from what we have now is that we are not necessarily publishing every tag we created. 
We can create a Draft Release with the workflow (which generates a tag and a bump of the version) but decide not to turn the Draft into a actual release.
