### PR TITLE
hotifx: accept range of peer dependencies for react

### DIFF
--- a/packages/ui-stencil-react/package.json
+++ b/packages/ui-stencil-react/package.json
@@ -29,8 +29,8 @@
     "typescript": "^5"
   },
   "peerDependencies": {
-    "react": "^17 || ^19",
-    "react-dom": "^17 || ^19"
+    "react": ">=17.0.0 <20.0.0",
+    "react-dom": ">=17.0.0 <20.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Peer dependencies were fixed on two major versions. We actually should be able to accept all between 17 up to 19