### PR TITLE
Expose only public components for React Wrapper

### DIFF
--- a/packages/ui-stencil-react/src/index.ts
+++ b/packages/ui-stencil-react/src/index.ts
@@ -1,4 +1,9 @@
-export { OramaSearchBox, OramaChatBox, OramaSearchButton } from './components/stencil-generated/components'
+export {
+  OramaSearchBox,
+  OramaChatBox,
+  OramaSearchButton,
+  OramaMarkdown,
+} from './components/stencil-generated/components'
 export { defineCustomElements } from '@orama/wc-components/loader'
 
 import '@orama/wc-components/dist/orama-ui/orama-ui.css'

--- a/packages/ui-stencil-react/src/index.ts
+++ b/packages/ui-stencil-react/src/index.ts
@@ -1,4 +1,4 @@
-export * from './components/stencil-generated/components'
+export { OramaSearchBox, OramaChatBox, OramaSearchButton } from './components/stencil-generated/components'
 export { defineCustomElements } from '@orama/wc-components/loader'
 
 import '@orama/wc-components/dist/orama-ui/orama-ui.css'


### PR DESCRIPTION
Exposes only components that user should be able to access. It includes only React Wrapper. 

https://linear.app/oramasearch/issue/ORM-1711/too-many-exports-create-confusion